### PR TITLE
Add default controller leader election setting values

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/stolostron/multicloud-operators-application/pkg/apis"
 	"github.com/stolostron/multicloud-operators-application/pkg/controller"
@@ -81,6 +82,9 @@ func RunManager() {
 		klog.Info("LeaderElection disabled as not running in a cluster")
 	}
 
+	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
+	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -88,6 +92,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-application-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
 	})
 	if err != nil {
 		klog.Error(err, "")

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -20,14 +20,20 @@ import (
 
 // ControllerRunOptions for the hcm controller.
 type ControllerRunOptions struct {
-	MetricsAddr        string
-	ApplicationCRDFile string
-	LeaderElect        bool
+	MetricsAddr          string
+	ApplicationCRDFile   string
+	LeaderElect          bool
+	LeaseDurationSeconds int
+	RenewDeadlineSeconds int
+	RetryPeriodSeconds   int
 }
 
 var options = ControllerRunOptions{
-	MetricsAddr:        "",
-	ApplicationCRDFile: "/usr/local/etc/application/crds/app.k8s.io_applications_crd_v1.yaml",
+	MetricsAddr:          "",
+	ApplicationCRDFile:   "/usr/local/etc/application/crds/app.k8s.io_applications_crd_v1.yaml",
+	LeaseDurationSeconds: 137,
+	RenewDeadlineSeconds: 107,
+	RetryPeriodSeconds:   26,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -54,5 +60,26 @@ func ProcessFlags() {
 		"leader-elect",
 		false,
 		"Enable a leader client to gain leadership before executing the main loop",
+	)
+
+	flag.IntVar(
+		&options.LeaseDurationSeconds,
+		"lease-duration",
+		options.LeaseDurationSeconds,
+		"The lease duration in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RenewDeadlineSeconds,
+		"renew-deadline",
+		options.RenewDeadlineSeconds,
+		"The renew deadline in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RetryPeriodSeconds,
+		"retry-period",
+		options.RetryPeriodSeconds,
+		"The retry period in seconds.",
 	)
 }


### PR DESCRIPTION
Following recommended default settings of leaseDuration=137s, renewDeadline=107s, and retryPeriod=26s from https://github.com/openshift/library-go/blob/4b9033d00d37b88393f837a88ff541a56fd13621/pkg/config/leaderelection/leaderelection.go#L84


https://github.com/stolostron/backlog/issues/25245
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>