### PR TITLE
Change lease-duration to leader-election-lease-duration

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -82,7 +82,7 @@ func RunManager() {
 		klog.Info("LeaderElection disabled as not running in a cluster")
 	}
 
-	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
 	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
 	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -20,20 +20,20 @@ import (
 
 // ControllerRunOptions for the hcm controller.
 type ControllerRunOptions struct {
-	MetricsAddr          string
-	ApplicationCRDFile   string
-	LeaderElect          bool
-	LeaseDurationSeconds int
-	RenewDeadlineSeconds int
-	RetryPeriodSeconds   int
+	MetricsAddr                        string
+	ApplicationCRDFile                 string
+	LeaderElect                        bool
+	LeaderElectionLeaseDurationSeconds int
+	RenewDeadlineSeconds               int
+	RetryPeriodSeconds                 int
 }
 
 var options = ControllerRunOptions{
-	MetricsAddr:          "",
-	ApplicationCRDFile:   "/usr/local/etc/application/crds/app.k8s.io_applications_crd_v1.yaml",
-	LeaseDurationSeconds: 137,
-	RenewDeadlineSeconds: 107,
-	RetryPeriodSeconds:   26,
+	MetricsAddr:                        "",
+	ApplicationCRDFile:                 "/usr/local/etc/application/crds/app.k8s.io_applications_crd_v1.yaml",
+	LeaderElectionLeaseDurationSeconds: 137,
+	RenewDeadlineSeconds:               107,
+	RetryPeriodSeconds:                 26,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -63,10 +63,10 @@ func ProcessFlags() {
 	)
 
 	flag.IntVar(
-		&options.LeaseDurationSeconds,
-		"lease-duration",
-		options.LeaseDurationSeconds,
-		"The lease duration in seconds.",
+		&options.LeaderElectionLeaseDurationSeconds,
+		"leader-election-lease-duration",
+		options.LeaderElectionLeaseDurationSeconds,
+		"The leader election lease duration in seconds.",
 	)
 
 	flag.IntVar(


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

While writing the [doc issue](https://github.com/stolostron/backlog/issues/25868) for https://github.com/stolostron/backlog/issues/25245 I noticed inconsistent naming of the lease duration flag. This change will keep the flag consistent for all the different parts of the controllers.