### PR TITLE
update go to 1.19

### DIFF
--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-application
 COPY . .

--- a/common/scripts/lint_go.sh
+++ b/common/scripts/lint_go.sh
@@ -15,4 +15,5 @@
 # limitations under the License.
 
 export GOLANGCI_LINT_CACHE=/tmp/golangci-cache
+export GOROOT=`go env GOROOT`
 GOGC=25 golangci-lint run -c ./common/config/.golangci.yml

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicloud-operators-application
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

By setting the GOROOT explicitly we can enable golangci-lint to work with go 1.19 with no changes to the linters and no errors. https://github.com/golangci/golangci-lint/issues/2374#issuecomment-1217930589

https://github.com/stolostron/backlog/issues/26283