### PR TITLE
Enforce server side TLSv1.2

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -95,6 +96,7 @@ func RunManager() {
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,
 		RetryPeriod:             &retryPeriod,
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 	if err != nil {
 		klog.Error(err, "")


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

PR enforces TLSv1.2 and confirmed using nmap script ssl-enum-ciphers:

Before enforcement:
```
| ssl-enum-ciphers: 
|   TLSv1.0: 
|     ciphers: 
|       ...
|   TLSv1.1: 
|     ciphers: 
|       ...
|   TLSv1.2: 
|     ciphers: 
|       ...
```

After enforcement:

```
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       ...
```


Addresses:
 - https://github.com/stolostron/backlog/issues/26685