### PR TITLE
Update leader election settings

### DIFF
--- a/build/run-code-lint.sh
+++ b/build/run-code-lint.sh
@@ -22,7 +22,7 @@ gem install mdl
 gem install awesome_bot
 
 # Install golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.46.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.52.2
 
 # Start lint task
 make -f Makefile.prow lint-all

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -172,7 +172,7 @@ func RunManager() {
 	}
 
 	go appWebhook.WireUpWebhookSupplymentryResource(sig, mgr, appWebhook.WebhookServiceName,
-		appWebhook.WebhookValidatorName, certDir, caCert)
+		appWebhook.WebhookValidatorName, caCert)
 
 	klog.Info("Starting the Cmd.")
 

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/stolostron/multicloud-operators-application/pkg/apis"
 	"github.com/stolostron/multicloud-operators-application/pkg/controller"
@@ -83,9 +82,11 @@ func RunManager() {
 		klog.Info("LeaderElection disabled as not running in a cluster")
 	}
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	klog.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -93,9 +94,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-application-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 	if err != nil {

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -15,25 +15,27 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
 // ControllerRunOptions for the hcm controller.
 type ControllerRunOptions struct {
-	MetricsAddr                        string
-	ApplicationCRDFile                 string
-	LeaderElect                        bool
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	ApplicationCRDFile          string
+	LeaderElect                 bool
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var options = ControllerRunOptions{
-	MetricsAddr:                        "",
-	ApplicationCRDFile:                 "/usr/local/etc/application/crds/app.k8s.io_applications_crd_v1.yaml",
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
+	MetricsAddr:                 "",
+	ApplicationCRDFile:          "/usr/local/etc/application/crds/app.k8s.io_applications_crd_v1.yaml",
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -62,24 +64,31 @@ func ProcessFlags() {
 		"Enable a leader client to gain leadership before executing the main loop",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 }

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -1,6 +1,6 @@
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the multicloudlab/tools repo.
-  golangci-lint-version: 1.46.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.52.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m
@@ -28,9 +28,11 @@ run:
 linters:
   enable-all: true
   disable:
+    - asasalint
     - bodyclose
     - contextcheck
     - cyclop
+    - deadcode
     - depguard
     - dupl
     - forbidigo
@@ -41,6 +43,7 @@ linters:
     - exhaustivestruct
     - forcetypeassert
     - gci
+    - ginkgolinter
     - gochecknoglobals
     - gochecknoinits
     - goconst
@@ -61,14 +64,18 @@ linters:
     - maligned
     - nakedret
     - nestif
+    - nilerr
     - nilnil
     - nlreturn
     - noctx
     - nonamedreturns
+    - nosnakecase
     - paralleltest
     - prealloc
     - predeclared
+    - rowserrcheck
     - staticcheck
+    - structcheck
     - scopelint
     - tagliatelle
     - tenv
@@ -77,6 +84,7 @@ linters:
     - varnamelen
     - wastedassign
     - wrapcheck
+    - varcheck
   fast: false
 
 linters-settings:

--- a/pkg/controller/application/application_controller_suite_test.go
+++ b/pkg/controller/application/application_controller_suite_test.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -57,7 +56,7 @@ func TestMain(m *testing.M) {
 }
 
 // StartTestManager adds recFn
-func StartTestManager(ctx context.Context, mgr manager.Manager, g *gomega.GomegaWithT) *sync.WaitGroup {
+func StartTestManager(ctx context.Context, mgr manager.Manager) *sync.WaitGroup {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 

--- a/pkg/controller/application/application_controller_test.go
+++ b/pkg/controller/application/application_controller_test.go
@@ -62,7 +62,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
-	mgrStopped := StartTestManager(ctx, mgr, g)
+	mgrStopped := StartTestManager(ctx, mgr)
 
 	defer func() {
 		cancel()

--- a/pkg/controller/application/hub.go
+++ b/pkg/controller/application/hub.go
@@ -70,7 +70,7 @@ func (r *ReconcileApplication) doAppHubReconcile(app *appv1beta1.Application) {
 // Then it is updated to the application name again. so the appsub is updated in a endless loop.
 // application crd/controller will deprecate in 2.6.
 
-//GetAllSubscriptionDeployablesByApplication get all subscriptions and their deployables.app.ibm.com objects by a application
+// GetAllSubscriptionDeployablesByApplication get all subscriptions and their deployables.app.ibm.com objects by a application
 func (r *ReconcileApplication) GetAllSubscriptionDeployablesByApplication(app *appv1beta1.Application,
 	allClusterDplMap map[string]*utils.DplMap) ([]*subv1.Subscription, error) {
 	var allSubs []*subv1.Subscription
@@ -146,7 +146,7 @@ func (r *ReconcileApplication) GetAllSubscriptionDeployablesByApplication(app *a
 	return allSubs, nil
 }
 
-//GetAllNewDeployablesByApplication get all deployables.app.ibm.com objects by a application
+// GetAllNewDeployablesByApplication get all deployables.app.ibm.com objects by a application
 func (r *ReconcileApplication) GetAllNewDeployablesByApplication(
 	app *appv1beta1.Application) ([]*subv1.Subscription, []*dplv1.Deployable, map[string]*utils.DplMap) {
 	var allSubs []*subv1.Subscription

--- a/utils/explore.go
+++ b/utils/explore.go
@@ -28,12 +28,12 @@ const (
 	ResourceLabelName = "name"
 )
 
-//DplMap store all dpl names for a cluster [dplName]
+// DplMap store all dpl names for a cluster [dplName]
 type DplMap struct {
 	DplResourceMap map[string]*dplv1alpha1.Deployable
 }
 
-//GetUniqueDeployables get unique deployable array
+// GetUniqueDeployables get unique deployable array
 func GetUniqueDeployables(allDpls []*dplv1alpha1.Deployable) []*dplv1alpha1.Deployable {
 	dplmap := make(map[string]*dplv1alpha1.Deployable)
 
@@ -50,7 +50,7 @@ func GetUniqueDeployables(allDpls []*dplv1alpha1.Deployable) []*dplv1alpha1.Depl
 	return newdpls
 }
 
-//GetUniqueSubscriptions get unique subscription array
+// GetUniqueSubscriptions get unique subscription array
 func GetUniqueSubscriptions(allSubs []*subv1alpha1.Subscription) []*subv1alpha1.Subscription {
 	submap := make(map[string]*subv1alpha1.Subscription)
 
@@ -67,7 +67,7 @@ func GetUniqueSubscriptions(allSubs []*subv1alpha1.Subscription) []*subv1alpha1.
 	return newsubs
 }
 
-//PrintAllClusterDplMap print all cluster deployable map
+// PrintAllClusterDplMap print all cluster deployable map
 func PrintAllClusterDplMap(allClusterDplMap map[string]*DplMap) {
 	for cluster, dplmap := range allClusterDplMap {
 		for dplname, dpl := range dplmap.DplResourceMap {
@@ -86,7 +86,7 @@ func PrintAllClusterDplMap(allClusterDplMap map[string]*DplMap) {
 	}
 }
 
-//AppendClusterDplMap append dpl and its deployed cluster to allClusterDplMap
+// AppendClusterDplMap append dpl and its deployed cluster to allClusterDplMap
 func AppendClusterDplMap(statusdpl dplv1alpha1.Deployable, dpl dplv1alpha1.Deployable, allClusterDplMap map[string]*DplMap) {
 	if statusdpl.Status.Phase == "Propagated" || statusdpl.Status.Phase == "Deployed" {
 		for cluster := range statusdpl.Status.PropagatedStatus {

--- a/utils/kubernetes_suite_test.go
+++ b/utils/kubernetes_suite_test.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +58,7 @@ func TestMain(m *testing.M) {
 }
 
 // StartTestManager adds recFn
-func StartTestManager(ctx context.Context, mgr manager.Manager, g *gomega.GomegaWithT) *sync.WaitGroup {
+func StartTestManager(ctx context.Context, mgr manager.Manager) *sync.WaitGroup {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 

--- a/utils/kubernetes_test.go
+++ b/utils/kubernetes_test.go
@@ -53,7 +53,7 @@ func TestCheckAndInstallCRD(t *testing.T) {
 
 	//start manager mgr
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
-	mgrStopped := StartTestManager(ctx, mgr, g)
+	mgrStopped := StartTestManager(ctx, mgr)
 
 	defer func() {
 		cancel()

--- a/webhook/application_validator.go
+++ b/webhook/application_validator.go
@@ -15,6 +15,7 @@
 package webhook
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,7 +39,7 @@ type AppValidator struct {
 //	    operator: In
 //	    values: val-app-1
 
-func (v *AppValidator) Handle(req admission.Request) admission.Response {
+func (v *AppValidator) Handle(_ context.Context, req admission.Request) admission.Response {
 	log.Info("entry webhook handle")
 	defer log.Info("exit webhook handle")
 

--- a/webhook/application_validator.go
+++ b/webhook/application_validator.go
@@ -15,7 +15,6 @@
 package webhook
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -39,7 +38,7 @@ type AppValidator struct {
 //	    operator: In
 //	    values: val-app-1
 
-func (v *AppValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+func (v *AppValidator) Handle(req admission.Request) admission.Response {
 	log.Info("entry webhook handle")
 	defer log.Info("exit webhook handle")
 

--- a/webhook/certificate.go
+++ b/webhook/certificate.go
@@ -65,7 +65,7 @@ func getSignedCASecretKey(whKey types.NamespacedName) types.NamespacedName {
 	}
 }
 
-//getSelfSignedCACert will try to get the CA from the secret, if it doesn't exit, then
+// getSelfSignedCACert will try to get the CA from the secret, if it doesn't exit, then
 // it will generate a self singed CA cert and store it to the secret.
 func getSelfSignedCACert(clt client.Client, certName string, whKey types.NamespacedName) (Certificate, error) {
 	srtIns := &corev1.Secret{}

--- a/webhook/webhook_suite_test.go
+++ b/webhook/webhook_suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func(done Done) {
 	}
 
 	var err error
-	// be careful, if we use shorthand assignment, the the cCfg will be a local variable
+	// be careful, if we use shorthand assignment, the Cfg will be a local variable
 	initializeWebhookInEnvironment()
 	cfg, err := testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
@@ -220,7 +220,7 @@ func initializeWebhookInEnvironment() {
 }
 
 // StartTestManager adds recFn
-func StartTestManager(ctx context.Context, mgr mgr.Manager, g *GomegaWithT) *sync.WaitGroup {
+func StartTestManager(ctx context.Context, mgr mgr.Manager) *sync.WaitGroup {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -37,7 +37,7 @@ func TestWireupWebhook(t *testing.T) {
 	k8sClient = mgr.GetClient()
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
-	mgrStopped := StartTestManager(ctx, mgr, g)
+	mgrStopped := StartTestManager(ctx, mgr)
 
 	defer func() {
 		cancel()
@@ -57,7 +57,7 @@ func TestWireupWebhook(t *testing.T) {
 	caCert, err := GenerateWebhookCerts(k8sClient, certDir)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	WireUpWebhookSupplymentryResource(ctx, mgr, wbhSvcNm, validatorName, certDir, caCert)
+	WireUpWebhookSupplymentryResource(ctx, mgr, wbhSvcNm, validatorName, caCert)
 
 	ns, err := findEnvVariable(podNamespaceEnvVar)
 	g.Expect(err).Should(BeNil())

--- a/webhook/wireupwebhook.go
+++ b/webhook/wireupwebhook.go
@@ -71,9 +71,9 @@ func WireUpWebhook(clt client.Client, mgr manager.Manager, whk *webhook.Server, 
 	return GenerateWebhookCerts(clt, certDir)
 }
 
-//assuming we have a service set up for the webhook, and the service is linking
-//to a secret which has the CA
-func WireUpWebhookSupplymentryResource(ctx context.Context, mgr manager.Manager, wbhSvcName, validatorName, certDir string, caCert []byte) {
+// assuming we have a service set up for the webhook, and the service is linking
+// to a secret which has the CA
+func WireUpWebhookSupplymentryResource(ctx context.Context, mgr manager.Manager, wbhSvcName, validatorName string, caCert []byte) {
 	log.Info("entry wire up webhook")
 	defer log.Info("exit wire up webhook ")
 


### PR DESCRIPTION
This PR updates the leader election settings and renames the leader election options from 
``` 
--renew-deadline ==> leader-election-renew-deadline
--retry-period ==> leader-election-retry-period
```

NOTE: Had to lint files, as unit tests failed due to old linter version with go 1.20.