### PR TITLE
ACM-5524 Enforce server side TLSv1.3

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -97,7 +97,7 @@ func RunManager() {
 		LeaseDuration:           &options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &options.LeaderElectionRetryPeriod,
-		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.3"},
 	})
 	if err != nil {
 		klog.Error(err, "")

--- a/webhook/application_validator.go
+++ b/webhook/application_validator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -40,8 +41,8 @@ type AppValidator struct {
 //	    values: val-app-1
 
 func (v *AppValidator) Handle(_ context.Context, req admission.Request) admission.Response {
-	log.Info("entry webhook handle")
-	defer log.Info("exit webhook handle")
+	klog.Info("entry webhook handle")
+	defer klog.Info("exit webhook handle")
 
 	app := &appv1beta1.Application{}
 

--- a/webhook/wireupwebhook.go
+++ b/webhook/wireupwebhook.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -59,13 +59,11 @@ const (
 	resourceName = "applications"
 )
 
-var log = logf.Log.WithName("operator-application-webhook")
-
 func WireUpWebhook(clt client.Client, mgr manager.Manager, whk *webhook.Server, certDir string) ([]byte, error) {
 	whk.Port = WebhookPort
 	whk.CertDir = certDir
 
-	log.Info("registering webhooks to the webhook server")
+	klog.Info("registering webhooks to the webhook server")
 	whk.Register(ValidatorPath, &webhook.Admission{Handler: &AppValidator{Client: mgr.GetClient()}})
 
 	return GenerateWebhookCerts(clt, certDir)
@@ -74,29 +72,29 @@ func WireUpWebhook(clt client.Client, mgr manager.Manager, whk *webhook.Server, 
 // assuming we have a service set up for the webhook, and the service is linking
 // to a secret which has the CA
 func WireUpWebhookSupplymentryResource(ctx context.Context, mgr manager.Manager, wbhSvcName, validatorName string, caCert []byte) {
-	log.Info("entry wire up webhook")
-	defer log.Info("exit wire up webhook ")
+	klog.Info("entry wire up webhook")
+	defer klog.Info("exit wire up webhook ")
 
 	podNs, err := findEnvVariable(podNamespaceEnvVar)
 	if err != nil {
-		log.Error(err, "failed to wire up webhook with kube")
+		klog.Error(err, "failed to wire up webhook with kube")
 	}
 
 	if !mgr.GetCache().WaitForCacheSync(ctx) {
-		log.Error(gerr.New("cache not started"), "failed to start up cache")
+		klog.Error(gerr.New("cache not started"), "failed to start up cache")
 	}
 
-	log.Info("cache is ready to consume")
+	klog.Info("cache is ready to consume")
 
 	clt := mgr.GetClient()
 
 	if err := createWebhookService(clt, wbhSvcName, podNs); err != nil {
-		log.Error(err, "failed to wire up webhook with kube")
+		klog.Error(err, "failed to wire up webhook with kube")
 		os.Exit(1)
 	}
 
 	if err := createOrUpdateValiatingWebhook(clt, wbhSvcName, validatorName, podNs, ValidatorPath, caCert); err != nil {
-		log.Error(err, "failed to wire up webhook with kube")
+		klog.Error(err, "failed to wire up webhook with kube")
 		os.Exit(1)
 	}
 }
@@ -127,13 +125,13 @@ func createWebhookService(c client.Client, wbhSvcName, namespace string) error {
 				return err
 			}
 
-			log.Info(fmt.Sprintf("Create %s/%s service", namespace, wbhSvcName))
+			klog.Info(fmt.Sprintf("Create %s/%s service", namespace, wbhSvcName))
 
 			return nil
 		}
 	}
 
-	log.Info(fmt.Sprintf("%s/%s service is found", namespace, wbhSvcName))
+	klog.Info(fmt.Sprintf("%s/%s service is found", namespace, wbhSvcName))
 
 	return nil
 }
@@ -152,7 +150,7 @@ func createOrUpdateValiatingWebhook(c client.Client, wbhSvcName, validatorName, 
 				return gerr.Wrap(err, fmt.Sprintf("Failed to create validating webhook %s", validatorName))
 			}
 
-			log.Info(fmt.Sprintf("Create validating webhook %s", validatorName))
+			klog.Info(fmt.Sprintf("Create validating webhook %s", validatorName))
 
 			return nil
 		}
@@ -171,7 +169,7 @@ func createOrUpdateValiatingWebhook(c client.Client, wbhSvcName, validatorName, 
 		return gerr.Wrap(err, fmt.Sprintf("Failed to update validating webhook %s", validatorName))
 	}
 
-	log.Info(fmt.Sprintf("Update validating webhook %s", validatorName))
+	klog.Info(fmt.Sprintf("Update validating webhook %s", validatorName))
 
 	return nil
 }
@@ -186,7 +184,7 @@ func setOwnerReferences(c client.Client, namespace string, obj metav1.Object) {
 	owner := &appsv1.Deployment{}
 
 	if err := c.Get(context.TODO(), key, owner); err != nil {
-		log.Error(err, fmt.Sprintf("Failed to set owner references for %s", obj.GetName()))
+		klog.Error(err, fmt.Sprintf("Failed to set owner references for %s", obj.GetName()))
 		return
 	}
 


### PR DESCRIPTION
This PR enforces sever side TLSv1.3, confirmed using nmap script ssl-enum-ciphers:

Before enforcement:
```
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|        ...
|   TLSv1.3: 
|     ciphers: 
|       ...
|_  least strength: C
```
After:
```
| ssl-enum-ciphers: 
|   TLSv1.3: 
|     ciphers: 
|      ...
|_  least strength: A
```

This PR also updates the webhook logging location, as before the webhook wasn't actually logging anything to the controller. Not sure if there is another location where these logs are meant to exist.


Addresses:
 - https://issues.redhat.com/browse/ACM-5224