### PR TITLE
use go env GOARCH when building go binaries on vairous platforms

### DIFF
--- a/common/scripts/gobuild.sh
+++ b/common/scripts/gobuild.sh
@@ -28,7 +28,7 @@ shift
 
 set -e
 
-BUILD_GOOS=${GOOS:-linux}
+BUILD_GOOS=${GOOS:-$(go env GOOS)}
 BUILD_GOARCH=${GOARCH:-$(go env GOARCH)}
 GOBINARY=${GOBINARY:-go}
 BUILDINFO=${BUILDINFO:-""}
@@ -44,6 +44,8 @@ export CGO_ENABLED=1
 if [[ "${STATIC}" !=  "1" ]];then
     LDFLAGS=""
 fi
+
+echo "Building for OS: ${BUILD_GOOS}, Architecture: ${BUILD_GOARCH}"
 
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-20550#